### PR TITLE
IBIS-IP_common_V1.1: fix typo in ExpectedDepartureTime

### DIFF
--- a/IBIS-IP_common_V1.1.xsd
+++ b/IBIS-IP_common_V1.1.xsd
@@ -184,7 +184,7 @@
 					<xs:documentation>Describes the mode of the leaving vehicle </xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="ExpectedDepatureTime" type="IBIS-IP.dateTime" minOccurs="0">
+			<xs:element name="ExpectedDepartureTime" type="IBIS-IP.dateTime" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>Information, at which time the leaving vehicle will depart</xs:documentation>
 				</xs:annotation>


### PR DESCRIPTION
see https://forum.vdv.de/viewtopic.php?f=8&t=81

Signed-off-by: Steffen Sledz <sledz@dresearch-fe.de>